### PR TITLE
Fix Image Path

### DIFF
--- a/components/atoms/portfolio-logo.vue
+++ b/components/atoms/portfolio-logo.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="portfolio-logo">
-    <img src="/s/images/logo.jpg">
+    <img :src="$img.addPortfolioPrefix('/s/images/logo.jpg')">
   </div>
 </template>
 

--- a/misc/img.js
+++ b/misc/img.js
@@ -1,0 +1,5 @@
+export default {
+  addPortfolioPrefix(path) {
+    return process.env.DEPLOY_ENV ? `/portfolio/${path}` : path
+  },
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,6 @@
 const pkg = require('./package')
 const StylelintPlugin = require('stylelint-webpack-plugin')
-const baseRoute = env => (env === 'GH_PAGES' ? '/portfolio/' : '/')
+const baseRoute = env => (env === 'GH_PAGES' ? '/portfolio' : '')
 
 module.exports = {
   mode: 'universal',
@@ -21,7 +21,7 @@ module.exports = {
       {
         rel: 'icon',
         type: 'image/x-icon',
-        href: baseRoute(process.env.DEPLOY_ENV) + 's/images/logo.jpg',
+        href: baseRoute(process.env.DEPLOY_ENV) + '/s/images/logo.jpg',
       },
     ],
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -45,6 +45,7 @@ module.exports = {
   */
   plugins: [
     '~/plugins/constant.js',
+    '~/plugins/img.js',
     '~/plugins/meta-info.js',
     { src: '~/plugins/aos.js', ssr: false },
     { src: '~/plugins/doughnut-chart.js', ssr: false },

--- a/plugins/img.js
+++ b/plugins/img.js
@@ -1,0 +1,6 @@
+import img from '~/misc/img'
+
+export default (ctx, inject) => {
+  ctx.$img = img
+  inject('img', img)
+}


### PR DESCRIPTION
## WHY
 - Github page service sets repository name as the base route in this project. Because of it, paths for any image should start with `portfolio`, which is the name of this repository. 