### PR TITLE
Add browerslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
       "cross-env NODE_ENV=production eslint"
     ]
   },
+  "browserslist": [
+    "> 0.1% in JP",
+    "ie >= 10",
+    "android >= 4.0"
+  ],
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.12",
     "@fortawesome/free-brands-svg-icons": "^5.6.3",


### PR DESCRIPTION
## WHY 
 - Setting `browserslist` option, I would like autoprefixer package to add suitable vendor properties in all available browsers in Japan. (the ones used even slightly as well.)
