### PR TITLE
fix firebase deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             else
               project_id=$DEV_PROJECT_ID
               npm run firebase:functions:config:set \
-              -- dev_portfolio.portfolio_env=dev \
+              -- --project $project_id dev_portfolio.portfolio_env=dev  \
               dev_portfolio.basic_auth_username=$BASIC_AUTH_USERNAME \
               dev_portfolio.basic_auth_password=$BASIC_AUTH_PASSWORD
             fi


### PR DESCRIPTION
## WHY
 - When deploying the application on firebase cloud function,  some env vars are set into firebase package. However, for that to be executed, firebase cli command needs `<projectId>` . So I pass it to firebase. 