### PR TITLE
Refactor intersection observer

### DIFF
--- a/app/components/molecules/portfolio-progress-bar.vue
+++ b/app/components/molecules/portfolio-progress-bar.vue
@@ -21,6 +21,13 @@ export default {
       default: () => {},
     },
   },
+
+  data() {
+    return {
+      intersectionObserver: null,
+    }
+  },
+
   mounted() {
     const observeFunc = entry => {
       if (entry.isIntersecting) {
@@ -28,8 +35,14 @@ export default {
       }
     }
 
-    new IntersectionObserver(entries => entries.forEach(observeFunc)).observe(this.$refs.bar)
+    this.intersectionObserver = new IntersectionObserver(entries => entries.forEach(observeFunc))
+    this.intersectionObserver.observe(this.$refs.bar)
   },
+
+  beforeDestroy() {
+    this.intersectionObserver.disconnect()
+  },
+
   methods: {
     activateProgress() {
       this.$refs.bar.style.width = `${this.skill.percent}%`

--- a/app/components/molecules/portfolio-progress-bar.vue
+++ b/app/components/molecules/portfolio-progress-bar.vue
@@ -22,15 +22,13 @@ export default {
     },
   },
   mounted() {
-    if (process.browser) {
-      const observeFunc = entry => {
-        if (entry.isIntersecting) {
-          this.activateProgress()
-        }
+    const observeFunc = entry => {
+      if (entry.isIntersecting) {
+        this.activateProgress()
       }
-
-      new IntersectionObserver(entries => entries.forEach(observeFunc)).observe(this.$refs.bar)
     }
+
+    new IntersectionObserver(entries => entries.forEach(observeFunc)).observe(this.$refs.bar)
   },
   methods: {
     activateProgress() {

--- a/app/components/molecules/portfolio-strength-item-card.vue
+++ b/app/components/molecules/portfolio-strength-item-card.vue
@@ -40,17 +40,14 @@ export default {
   },
 
   mounted() {
-    if (process.browser) {
-      const observeFunc = entry => {
-        if (entry.isIntersecting) {
-          this.fadeIn()
-        }
+    const observeOptions = { rootMargin: '-150px' }
+    const observeFunc = entry => {
+      if (entry.isIntersecting) {
+        this.fadeIn()
       }
-
-      const observeOptions = { rootMargin: '-150px' }
-
-      new IntersectionObserver(entries => entries.forEach(observeFunc), observeOptions).observe(this.$refs.portfolioStrengthItemCard)
     }
+
+    new IntersectionObserver(entries => entries.forEach(observeFunc), observeOptions).observe(this.$refs.portfolioStrengthItemCard)
   },
 
   methods: {

--- a/app/components/molecules/portfolio-strength-item-card.vue
+++ b/app/components/molecules/portfolio-strength-item-card.vue
@@ -36,6 +36,7 @@ export default {
   data() {
     return {
       displayed: false,
+      intersectionObserver: null,
     }
   },
 
@@ -47,7 +48,12 @@ export default {
       }
     }
 
-    new IntersectionObserver(entries => entries.forEach(observeFunc), observeOptions).observe(this.$refs.portfolioStrengthItemCard)
+    this.intersectionObserver = new IntersectionObserver(entries => entries.forEach(observeFunc), observeOptions)
+    this.intersectionObserver.observe(this.$refs.portfolioStrengthItemCard)
+  },
+
+  beforeDestroy() {
+    this.intersectionObserver.disconnect()
   },
 
   methods: {


### PR DESCRIPTION
## WHY
 - `process.browser` condition is not necessary in mounted lifecycle, which only runs on client side.
 - make sure intersection observer gets disconnected when the components get destroyed to prevent memory leak.