### PR TITLE
Display my articles from qiita

### DIFF
--- a/app/components/molecules/portfolio-tech-blog-item-card.vue
+++ b/app/components/molecules/portfolio-tech-blog-item-card.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="portfolio-tech-blog-item-card">
+    <a :href="item.url" target="_blank" rel="noopener">
+      <div class="item-title">
+        {{ item.title }}
+      </div>
+
+      <div class="item-likes-count">
+        いいね数 <font-awesome-icon class="likes-icon-class" :icon="likesIconClass" />{{ item.likes_count }}
+      </div>
+
+      <div class="item-tags">
+        <ul>
+          <li v-for="(tag, index) in item.tags" :key="index">
+            {{ tag.name }}
+          </li>
+        </ul>
+      </div>
+    </a>
+  </div>
+</template>
+
+<script lang="ts">
+import { QiitaItem } from '../../entities/qiita-item'
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+
+@Component
+export default class PortfolioTechBlogItemCard extends Vue {
+  likesIconClass: String[] = ['fas', 'thumbs-up']
+
+  @Prop({ type: Object, default: () => {} })
+  item!: QiitaItem
+}
+</script>
+
+<style lang="scss" scoped>
+.portfolio-tech-blog-item-card {
+  margin: 1.5em 0;
+  padding: 0.75em;
+  color: $dark_navy;
+  background: $white;
+  font-weight: bold;
+
+  .item-title {
+    margin-bottom: 1em;
+  }
+
+  .item-likes-count {
+    margin: 1em 0;
+
+    .likes-icon-class {
+      margin-right: 0.5em;
+    }
+  }
+
+  .item-tags {
+    ul {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+
+      li {
+        margin: 0.25em 0.5em 0.25em 0;
+        padding: 0.25em;
+        border: 1px solid $dark_navy;
+      }
+    }
+  }
+}
+</style>

--- a/app/components/molecules/portfolio-tech-blog-item-card.vue
+++ b/app/components/molecules/portfolio-tech-blog-item-card.vue
@@ -28,7 +28,7 @@ import { Component, Vue, Prop } from 'nuxt-property-decorator'
 export default class PortfolioTechBlogItemCard extends Vue {
   likesIconClass: String[] = ['fas', 'thumbs-up']
 
-  @Prop({ type: Object, default: () => {} })
+  @Prop({ type: Object as () => QiitaItem, default: () => {} })
   item!: QiitaItem
 }
 </script>

--- a/app/components/organisms/portfolio-header.vue
+++ b/app/components/organisms/portfolio-header.vue
@@ -25,7 +25,7 @@ export default class PortfolioHeader extends Vue {}
 
 <style lang="scss" scoped>
 .portfolio-header {
-  padding: 1em 2em;
+  padding: 1em 3.2%;
   background: $dark_navy;
   height: 100px;
 

--- a/app/components/organisms/portfolio-tech-blog-item-cards.vue
+++ b/app/components/organisms/portfolio-tech-blog-item-cards.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="portfolio-tech-blog-item-cards">
+    <ul>
+      <li 
+        v-for="(item, index) in items"
+        :key="index"
+      >
+        <portfolio-tech-blog-item-card :item="item" />
+      </li>    
+    </ul> 
+  </div>
+</template>
+
+<script lang="ts">
+import { QiitaItem } from '../../entities/qiita-item'
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+
+import PortfolioTechBlogItemCard from '../molecules/portfolio-tech-blog-item-card.vue'
+
+@Component({
+  components: {
+    PortfolioTechBlogItemCard,
+  },
+})
+export default class PortfolioTechBlogItemCards extends Vue {
+  @Prop({ type: Array, default: () => [] })
+  items!: QiitaItem[]
+}
+</script>
+
+<style lang="scss" scoped>
+.portfolio-tech-blog-item-cards {
+  max-width: 940px;
+  margin: 0 auto;
+
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    li {
+      width: 32%;
+    }
+  }
+
+  @media only screen and (max-width: $breakpoint-mobile) {
+    ul {
+      display: block;
+
+      li {
+        width: 100%;
+      }
+    }
+  }
+}
+</style>

--- a/app/entities/qiita-item.ts
+++ b/app/entities/qiita-item.ts
@@ -1,0 +1,29 @@
+export interface QiitaItem {
+  coediting: Boolean
+  comments_count: Number
+  created_at: String
+  group?: QiitaItemGroup
+  id: String
+  likes_count: Number
+  private: Boolean
+  reactions_count: Number
+  tags: QiitaItemTag[]
+  title: String
+  updated_at: String
+  url: String
+  page_views_count?: Number
+}
+
+interface QiitaItemGroup {
+  created_at: String
+  id: Number
+  name: String
+  private: Boolean
+  updated_at: String
+  url_name: String
+}
+
+interface QiitaItemTag {
+  name: String
+  versions: String[]
+}

--- a/app/pages/tech-blogs/index.vue
+++ b/app/pages/tech-blogs/index.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="portfolio-tech-blogs">
+    <div class="portfolio-tech-blogs-content">
+      <h1 class="text-h2">{{ pageTitle }}</h1>
+
+      <portfolio-tech-blog-item-cards :items="items" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { mapGetters } from 'vuex'
+import { Component, Vue } from 'nuxt-property-decorator'
+
+import PortfolioTechBlogItemCards from '../../components/organisms/portfolio-tech-blog-item-cards.vue'
+
+@Component({
+  components: {
+    PortfolioTechBlogItemCards,
+  },
+  computed: {
+    ...mapGetters({
+      items: 'qiita-items/items',
+    }),
+  },
+})
+export default class TechBlogsIndex extends Vue {
+  pageTitle: String = 'TECH BLOGS'
+
+  head() {
+    return {
+      title: this.pageTitle,
+    }
+  }
+
+  fetch({ store, app, error }) {
+    return app.$axiosErrorHandler(store.dispatch('qiita-items/fetch'), error)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.portfolio-tech-blogs {
+  background: $dark_navy;
+  color: $blue;
+
+  .portfolio-tech-blogs-content {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 1em 0;
+
+    @media only screen and (max-width: $breakpoint-mobile) {
+      padding: 1em 3.2%;
+    }
+  }
+}
+</style>

--- a/app/plugins/axios-error-handler.js
+++ b/app/plugins/axios-error-handler.js
@@ -1,0 +1,18 @@
+function axiosErrorHandler(promise, errorHandler) {
+  return promise.catch(err => {
+    if (!err.response) {
+      return err
+    }
+
+    errorHandler({
+      statusCode: err.response.status,
+      message: err.response.data.message,
+    })
+
+    return err
+  })
+}
+
+export default (ctx, inject) => {
+  inject('axiosErrorHandler', axiosErrorHandler)
+}

--- a/app/serverMiddleware/api/index.js
+++ b/app/serverMiddleware/api/index.js
@@ -1,0 +1,14 @@
+import express from 'express'
+import routes from '../routes'
+
+const router = express.Router()
+const app = express()
+
+app.disable('x-powered-by')
+
+app.use(routes.addAll(router))
+
+export default {
+  path: '/api',
+  handler: app,
+}

--- a/app/serverMiddleware/routes/index.js
+++ b/app/serverMiddleware/routes/index.js
@@ -1,8 +1,13 @@
 import qiita from './qiita'
+import apicache from 'apicache'
+
+const onlyStatus200 = (req, res) => res.statusCode === 200
+const cacheSuccesses = apicache.middleware('1 hour', onlyStatus200)
 
 class Routes {
   addAll(router) {
-    router.get('/qiita/items', qiita.getItems)
+    // qiitaの仕様だと1時間に60回しかリクエストが送れないみたいなので、オンメモリでキャッシュさせる。
+    router.get('/qiita/items', cacheSuccesses, qiita.getItems)
 
     return router
   }

--- a/app/serverMiddleware/routes/index.js
+++ b/app/serverMiddleware/routes/index.js
@@ -1,0 +1,11 @@
+import qiita from './qiita'
+
+class Routes {
+  addAll(router) {
+    router.get('/qiita/items', qiita.getItems)
+
+    return router
+  }
+}
+
+export default new Routes()

--- a/app/serverMiddleware/routes/qiita.js
+++ b/app/serverMiddleware/routes/qiita.js
@@ -1,0 +1,21 @@
+import serverConfig from '../../../portfolio.server.config'
+import request from 'superagent'
+
+export default {
+  getItems(req, res, next) {
+    request
+      .get(serverConfig.qiita.itemApi)
+      .then(response => {
+        response.body.forEach(element => {
+          delete element.user
+          delete element.body
+          delete element.rendered_body
+        })
+        res.json(response.body)
+      })
+      .catch(err => {
+        // TODO: エラーハンドリング。一旦qiita側でエラーだったら、空の配列を返す。
+        res.json([])
+      })
+  },
+}

--- a/app/serverMiddleware/routes/qiita.js
+++ b/app/serverMiddleware/routes/qiita.js
@@ -14,8 +14,19 @@ export default {
         res.json(response.body)
       })
       .catch(err => {
-        // TODO: エラーハンドリング。一旦qiita側でエラーだったら、空の配列を返す。
-        res.json([])
+        if (err.status == 403) {
+          const errorMessage = '記事を取得するのにエラーが発生しました。しばらく時間を置いてから再度アクセスしてください。'
+          const portfolioError = new Error(errorMessage)
+          portfolioError.data = {
+            code: err.status,
+            name: 'Unauthorized',
+            message: errorMessage,
+          }
+
+          return portfolioError
+        }
+
+        return err
       })
   },
 }

--- a/app/store/qiita-items.js
+++ b/app/store/qiita-items.js
@@ -1,0 +1,25 @@
+export const state = () => {
+  return {
+    items: [],
+  }
+}
+
+export const getters = {
+  items(state) {
+    return state.items
+  },
+}
+
+export const mutations = {
+  setItems(state, { items }) {
+    state.items = items
+  },
+}
+
+export const actions = {
+  fetch({ commit }) {
+    return this.$axios.get('/qiita/items').then(response => {
+      commit('setItems', { items: response.data })
+    })
+  },
+}

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -3729,6 +3729,11 @@
         }
       }
     },
+    "apicache": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.4.0.tgz",
+      "integrity": "sha512-pX/Sf9q9HNzAC5F+hPgxt8v3eQVZkXL/+8HpAnrDJXFmma80F2aHAAeWTql3BsG87lc3T6A7CFPNWMTl97L/7Q=="
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4042,8 +4042,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -5305,7 +5304,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5592,6 +5590,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -6312,8 +6315,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -7345,6 +7347,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
     "fast-text-encoding": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
@@ -7994,12 +8001,16 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -16783,6 +16794,72 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
+      }
+    },
+    "superagent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.0.tgz",
+      "integrity": "sha512-7V6JVx5N+eTL1MMqRBX0v0bG04UjrjAvvZJTF/VDH/SH2GjSLqlrcYepFlpTrXpm37aSY6h3GGVWGxXl/98TKA==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.6",
+        "form-data": "^2.3.3",
+        "formidable": "^1.2.1",
+        "methods": "^1.1.2",
+        "mime": "^2.4.4",
+        "qs": "^6.7.0",
+        "readable-stream": "^3.4.0",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "superstatic": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -27,8 +27,9 @@
     "firebase-functions": "2.2.0",
     "nuxt": "2.8.1",
     "nuxt-fontawesome": "0.4.0",
-    "ts-node": "8.3.0",
-    "nuxt-property-decorator": "2.3.0"
+    "nuxt-property-decorator": "2.3.0",
+    "superagent": "5.1.0",
+    "ts-node": "8.3.0"
   },
   "devDependencies": {
     "@nuxt/typescript": "2.8.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,6 +20,7 @@
     "@fortawesome/vue-fontawesome": "0.1.6",
     "@nuxtjs/axios": "5.3.6",
     "@nuxtjs/dotenv": "1.3.0",
+    "apicache": "1.4.0",
     "basic-auth-connect": "1.0.0",
     "cross-env": "5.2.0",
     "express": "4.16.4",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -37,7 +37,7 @@ module.exports = {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: ['~/plugins/constant.js', '~/plugins/meta-info.ts', '~/plugins/portfolio-context.js'],
+  plugins: ['~/plugins/constant.js', '~/plugins/meta-info.ts', '~/plugins/portfolio-context.js', '~/plugins/axios-error-handler.js'],
 
   /*
    ** Nuxt.js modules

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -77,6 +77,8 @@ module.exports = {
     scss: './assets/styles/variables/*.scss',
   },
 
+  serverMiddleware: ['~/serverMiddleware/api/index.js'],
+
   /*
    ** Build configuration
    */

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,6 +71,8 @@ module.exports = {
    */
   axios: {
     // See https://github.com/nuxt-community/axios-module#options
+    baseURL: portfolioContext.api.baseURL,
+    browserBaseURL: portfolioContext.api.browserBaseURL,
   },
 
   styleResources: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3397,8 +3397,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -4782,7 +4781,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5052,6 +5050,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -5732,8 +5735,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -6726,6 +6728,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
     "fast-url-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -7232,12 +7239,16 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -15346,6 +15357,59 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
+      }
+    },
+    "superagent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.0.tgz",
+      "integrity": "sha512-7V6JVx5N+eTL1MMqRBX0v0bG04UjrjAvvZJTF/VDH/SH2GjSLqlrcYepFlpTrXpm37aSY6h3GGVWGxXl/98TKA==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.6",
+        "form-data": "^2.3.3",
+        "formidable": "^1.2.1",
+        "methods": "^1.1.2",
+        "mime": "^2.4.4",
+        "qs": "^6.7.0",
+        "readable-stream": "^3.4.0",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "superstatic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3167,6 +3167,11 @@
         }
       }
     },
+    "apicache": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.4.0.tgz",
+      "integrity": "sha512-pX/Sf9q9HNzAC5F+hPgxt8v3eQVZkXL/+8HpAnrDJXFmma80F2aHAAeWTql3BsG87lc3T6A7CFPNWMTl97L/7Q=="
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "nuxt": "2.8.1",
     "nuxt-fontawesome": "0.4.0",
     "nuxt-property-decorator": "2.3.0",
+    "superagent": "5.1.0",
     "ts-node": "8.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@fortawesome/vue-fontawesome": "0.1.6",
     "@nuxtjs/axios": "5.3.6",
     "@nuxtjs/dotenv": "1.3.0",
+    "apicache": "1.4.0",
     "cross-env": "5.2.0",
     "express": "4.16.4",
     "nuxt": "2.8.1",

--- a/portfolio.config.js
+++ b/portfolio.config.js
@@ -1,9 +1,22 @@
-const localDomain = 'localhost:3000'
+const prdUrl = 'https://portfolio-3bcd1.firebaseapp.com'
+const devUrl = 'https://dev-portfolio-6bfd1.firebaseapp.com/'
+const localUrl = 'http://localhost:3000'
+
+function getRootUrl() {
+  switch (process.env.portfolio_env) {
+    case 'prd':
+      return prdUrl
+    case 'dev':
+      return devUrl
+    default:
+      return localUrl
+  }
+}
 
 module.exports = {
   api: {
-    baseURL: `http://${localDomain}/api`,
-    browserBaseURL: `http://${localDomain}/api`,
+    baseURL: `${getRootUrl()}/api`,
+    browserBaseURL: `${getRootUrl()}/api`,
   },
   twitter: {
     url: 'https://twitter.com/romukey',

--- a/portfolio.config.js
+++ b/portfolio.config.js
@@ -1,4 +1,10 @@
+const localDomain = 'localhost:3000'
+
 module.exports = {
+  api: {
+    baseURL: `http://${localDomain}/api`,
+    browserBaseURL: `http://${localDomain}/api`,
+  },
   twitter: {
     url: 'https://twitter.com/romukey',
   },

--- a/portfolio.server.config.js
+++ b/portfolio.server.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  qiita: {
+    itemApi: 'https://qiita.com/api/v2/users/romukey/items',
+  },
+}


### PR DESCRIPTION
## WHY
 - Display my articles on qiita by calling apis provided by it.
 - Install `superagent`, `apicache`
   - According to qiita docs, api calls can be sent only 60 times within one hour. So I decide to cache response data from qiita on express server, which leads to reduce the number of requests. 
 - set `/api/qiita/items` route to delete unnecessary data.
 - add `axios-error-handler` plugin.